### PR TITLE
Improve ts typing + change crossdomain name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,6 @@
-import * as fastify from "fastify";
-import * as http from "http";
+import * as fastify from 'fastify';
+import * as http from 'http';
 
-declare module fastifyHelmet {
-  interface FastifyHelmetOptions {
-    contentSecurityPolicy?: any;
-    dnsPrefetchControl?: any;
-    expectCt?: any;
-    frameguard?: any;
-    hidePoweredBy?: any;
-    hpkp?: any;
-    hsts?: any;
-    ieNoOpen?: any;
-    noCache?: any;
-    noSniff?: any;
-    referrerPolicy?: any;
-    xssFilter?: any;
-  }
-}
 
 declare let fastifyHelmet: fastify.Plugin<
   http.Server,
@@ -26,3 +10,156 @@ declare let fastifyHelmet: fastify.Plugin<
 >;
 
 export = fastifyHelmet;
+
+declare namespace fastifyHelmet {
+  interface FastifyHelmetOptions extends IHelmetConfiguration {}
+
+  interface IHelmetConfiguration {
+    contentSecurityPolicy?: boolean | IHelmetContentSecurityPolicyConfiguration;
+    dnsPrefetchControl?: boolean | IHelmetDnsPrefetchControlConfiguration;
+    frameguard?: boolean | IHelmetFrameguardConfiguration;
+    hidePoweredBy?: boolean | IHelmetHidePoweredByConfiguration;
+    hpkp?: boolean | IHelmetHpkpConfiguration;
+    hsts?: boolean | IHelmetHstsConfiguration;
+    ieNoOpen?: boolean;
+    noCache?: boolean;
+    noSniff?: boolean;
+    referrerPolicy?: boolean | IHelmetReferrerPolicyConfiguration;
+    xssFilter?: boolean | IHelmetXssFilterConfiguration;
+    expectCt?: boolean | IHelmetExpectCtConfiguration;
+    permittedCrossDomainPolicies?: boolean | IHelmetPermittedCrossDomainPoliciesConfiguration;
+  }
+
+  interface IHelmetPermittedCrossDomainPoliciesConfiguration {
+    permittedPolicies?: string;
+  }
+
+  interface IHelmetContentSecurityPolicyDirectiveFunction {
+    (req: fastify.FastifyRequest<http.IncomingMessage>, res: fastify.FastifyReply<http.ServerResponse>): string;
+  }
+  type HelmetCspDirectiveValue = string | IHelmetContentSecurityPolicyDirectiveFunction;
+
+  type HelmetCspSandboxDirective =
+    | string
+    | 'allow-forms'
+    | 'allow-modals'
+    | 'allow-orientation-lock'
+    | 'allow-pointer-lock'
+    | 'allow-popups-to-escape-sandbox'
+    | 'allow-popups'
+    | 'allow-presentation'
+    | 'allow-same-origin'
+    | 'allow-scripts'
+    | 'allow-top-navigation';
+
+  type HelmetCspRequireSriForValue = string | 'script' | 'style';
+
+  interface IHelmetContentSecurityPolicyDirectives {
+    baseUri?: HelmetCspDirectiveValue[];
+    blockAllMixedContent?: boolean;
+    childSrc?: HelmetCspDirectiveValue[];
+    connectSrc?: HelmetCspDirectiveValue[];
+    defaultSrc?: HelmetCspDirectiveValue[];
+    fontSrc?: HelmetCspDirectiveValue[];
+    formAction?: HelmetCspDirectiveValue[];
+    frameAncestors?: HelmetCspDirectiveValue[];
+    frameSrc?: HelmetCspDirectiveValue[];
+    imgSrc?: HelmetCspDirectiveValue[];
+    manifestSrc?: HelmetCspDirectiveValue[];
+    mediaSrc?: HelmetCspDirectiveValue[];
+    objectSrc?: HelmetCspDirectiveValue[];
+    pluginTypes?: HelmetCspDirectiveValue[];
+    prefetchSrc?: HelmetCspDirectiveValue[];
+    reportTo?: HelmetCspDirectiveValue;
+    reportUri?: HelmetCspDirectiveValue;
+    requireSriFor?: HelmetCspRequireSriForValue[];
+    sandbox?: HelmetCspSandboxDirective[];
+    scriptSrc?: HelmetCspDirectiveValue[];
+    styleSrc?: HelmetCspDirectiveValue[];
+    upgradeInsecureRequests?: boolean;
+    workerSrc?: HelmetCspDirectiveValue[];
+  }
+
+  interface IHelmetContentSecurityPolicyDirectives {
+    'base-uri'?: HelmetCspDirectiveValue[];
+    'block-all-mixed-content'?: boolean;
+    'child-src'?: HelmetCspDirectiveValue[];
+    'connect-src'?: HelmetCspDirectiveValue[];
+    'default-src'?: HelmetCspDirectiveValue[];
+    'font-src'?: HelmetCspDirectiveValue[];
+    'form-action'?: HelmetCspDirectiveValue[];
+    'frame-ancestors'?: HelmetCspDirectiveValue[];
+    'frame-src'?: HelmetCspDirectiveValue[];
+    'img-src'?: HelmetCspDirectiveValue[];
+    'manifest-src'?: HelmetCspDirectiveValue[];
+    'media-src'?: HelmetCspDirectiveValue[];
+    'object-src'?: HelmetCspDirectiveValue[];
+    'plugin-types'?: HelmetCspDirectiveValue[];
+    'prefetch-src'?: HelmetCspDirectiveValue[];
+    'report-to'?: HelmetCspDirectiveValue;
+    'report-uri'?: HelmetCspDirectiveValue;
+    'require-sri-for'?: HelmetCspRequireSriForValue[];
+    sandbox?: HelmetCspSandboxDirective[];
+    'script-src'?: HelmetCspDirectiveValue;
+    'style-src'?: HelmetCspDirectiveValue;
+    'upgrade-insecure-requests'?: boolean;
+    'worker-src'?: HelmetCspDirectiveValue;
+  }
+
+  interface IHelmetContentSecurityPolicyConfiguration {
+    reportOnly?: boolean | ((req: fastify.FastifyRequest<http.IncomingMessage>, res: fastify.FastifyReply<http.ServerResponse>) => boolean);
+    setAllHeaders?: boolean;
+    disableAndroid?: boolean;
+    browserSniff?: boolean;
+    directives?: IHelmetContentSecurityPolicyDirectives;
+    loose?: boolean;
+  }
+
+  interface IHelmetDnsPrefetchControlConfiguration {
+    allow?: boolean;
+  }
+
+  interface IHelmetFrameguardConfiguration {
+    action?: string;
+    domain?: string;
+  }
+
+  interface IHelmetHidePoweredByConfiguration {
+    setTo?: string;
+  }
+
+  interface IHelmetSetIfFunction {
+    (req: fastify.FastifyRequest<http.IncomingMessage>, res: fastify.FastifyReply<http.ServerResponse>): boolean;
+  }
+
+  interface IHelmetHpkpConfiguration {
+    maxAge: number;
+    sha256s: string[];
+    includeSubdomains?: boolean;
+    reportUri?: string;
+    reportOnly?: boolean;
+    setIf?: IHelmetSetIfFunction;
+  }
+
+  interface IHelmetHstsConfiguration {
+    maxAge?: number;
+    includeSubdomains?: boolean;
+    preload?: boolean;
+    setIf?: IHelmetSetIfFunction;
+    force?: boolean;
+  }
+
+  interface IHelmetReferrerPolicyConfiguration {
+    policy?: string;
+  }
+
+  interface IHelmetXssFilterConfiguration {
+    setOnOldIE?: boolean;
+  }
+
+  interface IHelmetExpectCtConfiguration {
+    enforce?: boolean;
+    maxAge?: number;
+    reportUri?: string;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,6 @@
+// Type definitions for fastify-helmet
+// Types are heavily based on the type definitions from helmet
+
 import * as fastify from 'fastify';
 import * as http from 'http';
 
@@ -12,11 +15,12 @@ declare let fastifyHelmet: fastify.Plugin<
 export = fastifyHelmet;
 
 declare namespace fastifyHelmet {
-  interface FastifyHelmetOptions extends IHelmetConfiguration {}
 
-  interface IHelmetConfiguration {
+  interface FastifyHelmetOptions {
     contentSecurityPolicy?: boolean | IHelmetContentSecurityPolicyConfiguration;
     dnsPrefetchControl?: boolean | IHelmetDnsPrefetchControlConfiguration;
+    expectCt?: boolean | IHelmetExpectCtConfiguration;
+    featurePolicy?: IHelmetFeaturePolicyConfigurationStrict | IHelmetFeaturePolicyConfiguration;
     frameguard?: boolean | IHelmetFrameguardConfiguration;
     hidePoweredBy?: boolean | IHelmetHidePoweredByConfiguration;
     hpkp?: boolean | IHelmetHpkpConfiguration;
@@ -24,10 +28,9 @@ declare namespace fastifyHelmet {
     ieNoOpen?: boolean;
     noCache?: boolean;
     noSniff?: boolean;
+    permittedCrossDomainPolicies?: boolean | IHelmetPermittedCrossDomainPoliciesConfiguration;
     referrerPolicy?: boolean | IHelmetReferrerPolicyConfiguration;
     xssFilter?: boolean | IHelmetXssFilterConfiguration;
-    expectCt?: boolean | IHelmetExpectCtConfiguration;
-    permittedCrossDomainPolicies?: boolean | IHelmetPermittedCrossDomainPoliciesConfiguration;
   }
 
   interface IHelmetPermittedCrossDomainPoliciesConfiguration {
@@ -37,6 +40,7 @@ declare namespace fastifyHelmet {
   interface IHelmetContentSecurityPolicyDirectiveFunction {
     (req: fastify.FastifyRequest<http.IncomingMessage>, res: fastify.FastifyReply<http.ServerResponse>): string;
   }
+
   type HelmetCspDirectiveValue = string | IHelmetContentSecurityPolicyDirectiveFunction;
 
   type HelmetCspSandboxDirective =
@@ -117,6 +121,34 @@ declare namespace fastifyHelmet {
 
   interface IHelmetDnsPrefetchControlConfiguration {
     allow?: boolean;
+  }
+
+  interface IHelmetFeaturePolicyConfiguration {
+    features: {
+      [key: string]: string[];
+    }
+  }
+
+  interface IHelmetFeaturePolicyConfigurationStrict {
+    features: {
+      geolocation?: string[];
+      midi?: string[];
+      notifications?: string[];
+      push?: string[];
+      syncXhr?: string[];
+      microphone?: string[];
+      camera?: string[];
+      magnetometer?: string[];
+      gyroscope?: string[];
+      speaker?: string[];
+      vibrate?: string[];
+      fullscreen?: string[];
+      payment?: string[];
+      accelerometer?: string[];
+      usb?: string[];
+      vr?: string[];
+      autoplay?: string[];
+    }
   }
 
   interface IHelmetFrameguardConfiguration {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const fp = require('fastify-plugin')
 const config = require('./config')
 const helmet = {
   contentSecurityPolicy: require('helmet-csp'),
-  crossdomain: require('helmet-crossdomain'),
   dnsPrefetchControl: require('dns-prefetch-control'),
   expectCt: require('expect-ct'),
   featurePolicy: require('feature-policy'),
@@ -15,6 +14,7 @@ const helmet = {
   ieNoOpen: require('ienoopen'),
   noCache: require('nocache'),
   noSniff: require('dont-sniff-mimetype'),
+  permittedCrossDomainPolicies: require('helmet-crossdomain'),
   referrerPolicy: require('referrer-policy'),
   xssFilter: require('x-xss-protection')
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "typescript": "tsc --project ./tsconfig.json",
-    "test": "standard | snazzy && tap test.js"
+    "test": "standard | snazzy && tap test.js && npm run typescript"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ test('set the default headers', (t) => {
 test('sets default cross-domain-policy', (t) => {
   const fastify = Fastify()
 
-  fastify.register(helmet, { crossdomain: true })
+  fastify.register(helmet, { permittedCrossDomainPolicies: true })
 
   fastify.get('/', (request, reply) => {
     reply.send({ hello: 'world' })
@@ -46,6 +46,28 @@ test('sets default cross-domain-policy', (t) => {
     t.error(err)
     const expected = {
       'x-permitted-cross-domain-policies': 'none'
+    }
+
+    t.include(res.headers, expected)
+    t.end()
+  })
+})
+test('can set cross-domain-policy', (t) => {
+  const fastify = Fastify()
+
+  fastify.register(helmet, { permittedCrossDomainPolicies: { permittedPolicies: 'by-content-type' } })
+
+  fastify.get('/', (request, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const expected = {
+      'x-permitted-cross-domain-policies': 'by-content-type'
     }
 
     t.include(res.headers, expected)

--- a/types.test.ts
+++ b/types.test.ts
@@ -92,6 +92,11 @@ function dnsPrefetchControlTest() {
   app.register(fastifyHelmet, { dnsPrefetchControl: { allow: true } });
 }
 
+function featurePolicyTest() {
+  app.register(fastifyHelmet, { featurePolicy: { features: {notifications: ['self']} } });
+  app.register(fastifyHelmet, { featurePolicy: { features: {supportedButNotYetTyped: ["'self'"]} } });
+}
+
 function frameguardTest() {
   app.register(fastifyHelmet, { frameguard: {} });
   app.register(fastifyHelmet, { frameguard: { action: "deny" } });

--- a/types.test.ts
+++ b/types.test.ts
@@ -1,6 +1,235 @@
+import * as http from "http";
 import fastifyHelmet = require("../fastify-helmet");
 import fastify = require("fastify");
 
 const app = fastify();
 
-app.register(fastifyHelmet, { hpkp: true });
+function helmetTest() {
+  app.register(fastifyHelmet);
+  app.register(fastifyHelmet, {});
+  app.register(fastifyHelmet, { frameguard: false });
+  app.register(fastifyHelmet, { frameguard: true });
+  app.register(fastifyHelmet, {
+    frameguard: {
+      action: "deny"
+    }
+  });
+}
+
+function contentSecurityPolicyTest() {
+  const emptyArray: string[] = [];
+  const config: fastifyHelmet.IHelmetContentSecurityPolicyConfiguration = {
+    directives: {
+      baseUri: ["base.example.com"],
+      blockAllMixedContent: true,
+      childSrc: ["child.example.com"],
+      connectSrc: ["connect.example.com"],
+      defaultSrc: ["*"],
+      fontSrc: ["font.example.com"],
+      formAction: ["formaction.example.com"],
+      frameAncestors: ["'none'"],
+      frameSrc: emptyArray,
+      imgSrc: ["images.example.com"],
+      mediaSrc: ["media.example.com"],
+      manifestSrc: ["manifest.example.com"],
+      objectSrc: ["objects.example.com"],
+      pluginTypes: emptyArray,
+      prefetchSrc: ["prefetch.example.com"],
+      reportUri: "/some-url",
+      reportTo: "report.example.com",
+      requireSriFor: emptyArray,
+      sandbox: ["allow-presentation"],
+      scriptSrc: [
+        "scripts.example.com",
+        function(
+          req: fastify.FastifyRequest<http.IncomingMessage>,
+          res: fastify.FastifyReply<http.ServerResponse>
+        ) {
+          return "'nonce-abc123'";
+        }
+      ],
+      styleSrc: ["css.example.com"],
+      upgradeInsecureRequests: true,
+      workerSrc: ["worker.example.com"]
+    },
+    reportOnly: false,
+    setAllHeaders: false,
+    disableAndroid: false
+  };
+
+  function reportUriCb(
+    req: fastify.FastifyRequest<http.IncomingMessage>,
+    res: fastify.FastifyReply<http.ServerResponse>
+  ) {
+    return "/some-uri";
+  }
+  function reportOnlyCb(
+    req: fastify.FastifyRequest<http.IncomingMessage>,
+    res: fastify.FastifyReply<http.ServerResponse>
+  ) {
+    return false;
+  }
+
+  app.register(fastifyHelmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        reportUri: reportUriCb,
+        "report-uri": reportUriCb,
+        reportTo: reportUriCb,
+        "report-to": reportUriCb
+      },
+      reportOnly: reportOnlyCb,
+      loose: false,
+      setAllHeaders: true
+    }
+  });
+}
+
+function dnsPrefetchControlTest() {
+  app.register(fastifyHelmet, { dnsPrefetchControl: {} });
+  app.register(fastifyHelmet, { dnsPrefetchControl: { allow: false } });
+  app.register(fastifyHelmet, { dnsPrefetchControl: { allow: true } });
+}
+
+function frameguardTest() {
+  app.register(fastifyHelmet, { frameguard: {} });
+  app.register(fastifyHelmet, { frameguard: { action: "deny" } });
+  app.register(fastifyHelmet, { frameguard: { action: "sameorigin" } });
+  app.register(fastifyHelmet, {
+    frameguard: {
+      action: "allow-from",
+      domain: "http://example.com"
+    }
+  });
+}
+
+function hidePoweredBy() {
+  app.register(fastifyHelmet, { hidePoweredBy: {} });
+  app.register(fastifyHelmet, { hidePoweredBy: { setTo: "PHP 4.2.0" } });
+}
+
+function hpkpTest() {
+  app.register(fastifyHelmet, { hpkp: true });
+
+  app.register(fastifyHelmet, {
+    hpkp: {
+      maxAge: 7776000000,
+      sha256s: ["AbCdEf123=", "ZyXwVu456="]
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hpkp: {
+      maxAge: 7776000000,
+      sha256s: ["AbCdEf123=", "ZyXwVu456="],
+      includeSubdomains: false
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hpkp: {
+      maxAge: 7776000000,
+      sha256s: ["AbCdEf123=", "ZyXwVu456="],
+      includeSubdomains: true
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hpkp: {
+      maxAge: 7776000000,
+      sha256s: ["AbCdEf123=", "ZyXwVu456="],
+      reportUri: "http://example.com"
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hpkp: {
+      maxAge: 7776000000,
+      sha256s: ["AbCdEf123=", "ZyXwVu456="],
+      reportOnly: true
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hpkp: {
+      maxAge: 7776000000,
+      sha256s: ["AbCdEf123=", "ZyXwVu456="],
+      setIf: function(req, res) {
+        return true;
+      }
+    }
+  });
+}
+
+function hstsTest() {
+  app.register(fastifyHelmet, { hsts: { maxAge: 7776000000 } });
+
+  app.register(fastifyHelmet, {
+    hsts: {
+      maxAge: 7776000000
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hsts: {
+      maxAge: 7776000000,
+      includeSubdomains: true
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hsts: {
+      maxAge: 7776000000,
+      preload: true
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hsts: {
+      maxAge: 7776000000,
+      force: true
+    }
+  });
+
+  app.register(fastifyHelmet, {
+    hsts: {
+      maxAge: 7776000000,
+      setIf: function(req, res) {
+        return true;
+      }
+    }
+  });
+}
+
+function ieNoOpenTest() {
+  app.register(fastifyHelmet, { ieNoOpen: true });
+  app.register(fastifyHelmet, { ieNoOpen: undefined });
+}
+
+function noCacheTest() {
+  app.register(fastifyHelmet, { noCache: true });
+  app.register(fastifyHelmet, { noCache: false });
+}
+
+function noSniffTest() {
+  app.register(fastifyHelmet, { noSniff: true });
+  app.register(fastifyHelmet, { noSniff: false });
+}
+
+function referrerPolicyTest() {
+  app.register(fastifyHelmet, { referrerPolicy: { policy: "same-origin" } });
+}
+
+function xssFilterTest() {
+  app.register(fastifyHelmet, { xssFilter: {} });
+  app.register(fastifyHelmet, { xssFilter: { setOnOldIE: false } });
+  app.register(fastifyHelmet, { xssFilter: { setOnOldIE: true } });
+}
+
+function permittedCrossDomainPoliciesTest() {
+  app.register(fastifyHelmet, { permittedCrossDomainPolicies: true });
+  app.register(fastifyHelmet, {
+    permittedCrossDomainPolicies: { permittedPolicies: "none" }
+  });
+}


### PR DESCRIPTION
The types added are mostly identical to the ones defined in [DefinitelyTyped/helmetjs](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/helmet)

I'm a little unsure about the types that Fastify uses vs the types express use when a function is passed. For example: 
```typescript
// fastify 
interface IHelmetContentSecurityPolicyDirectiveFunction {
  (req: fastify.FastifyRequest<http.IncomingMessage>, res: fastify.FastifyReply<http.ServerResponse>): string;
}

// express
export interface IHelmetContentSecurityPolicyDirectiveFunction {
    (req: express.Request, res: express.Response): string;
}
```

I hope someone else can also test this before it is merged. I'm worried it might break peoples build as the types may be too strict.