### PR TITLE
Fix typescript type for sandbox csp directive

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ declare namespace fastifyHelmet {
     reportTo?: HelmetCspDirectiveValue;
     reportUri?: HelmetCspDirectiveValue;
     requireSriFor?: HelmetCspRequireSriForValue[];
-    sandbox?: HelmetCspSandboxDirective[];
+    sandbox?: HelmetCspSandboxDirective[] | true;
     scriptSrc?: HelmetCspDirectiveValue[];
     styleSrc?: HelmetCspDirectiveValue[];
     upgradeInsecureRequests?: boolean;
@@ -103,7 +103,7 @@ declare namespace fastifyHelmet {
     'report-to'?: HelmetCspDirectiveValue;
     'report-uri'?: HelmetCspDirectiveValue;
     'require-sri-for'?: HelmetCspRequireSriForValue[];
-    sandbox?: HelmetCspSandboxDirective[];
+    sandbox?: HelmetCspSandboxDirective[] | true;
     'script-src'?: HelmetCspDirectiveValue;
     'style-src'?: HelmetCspDirectiveValue;
     'upgrade-insecure-requests'?: boolean;

--- a/types.test.ts
+++ b/types.test.ts
@@ -57,6 +57,45 @@ function contentSecurityPolicyTest() {
     disableAndroid: false
   };
 
+  const configWithBooleanSandbox: fastifyHelmet.IHelmetContentSecurityPolicyConfiguration = {
+    directives: {
+      baseUri: ["base.example.com"],
+      blockAllMixedContent: true,
+      childSrc: ["child.example.com"],
+      connectSrc: ["connect.example.com"],
+      defaultSrc: ["*"],
+      fontSrc: ["font.example.com"],
+      formAction: ["formaction.example.com"],
+      frameAncestors: ["'none'"],
+      frameSrc: emptyArray,
+      imgSrc: ["images.example.com"],
+      mediaSrc: ["media.example.com"],
+      manifestSrc: ["manifest.example.com"],
+      objectSrc: ["objects.example.com"],
+      pluginTypes: emptyArray,
+      prefetchSrc: ["prefetch.example.com"],
+      reportUri: "/some-url",
+      reportTo: "report.example.com",
+      requireSriFor: emptyArray,
+      sandbox: true,
+      scriptSrc: [
+        "scripts.example.com",
+        function(
+          req: fastify.FastifyRequest<http.IncomingMessage>,
+          res: fastify.FastifyReply<http.ServerResponse>
+        ) {
+          return "'nonce-abc123'";
+        }
+      ],
+      styleSrc: ["css.example.com"],
+      upgradeInsecureRequests: true,
+      workerSrc: ["worker.example.com"]
+    },
+    reportOnly: false,
+    setAllHeaders: false,
+    disableAndroid: false
+  };
+
   function reportUriCb(
     req: fastify.FastifyRequest<http.IncomingMessage>,
     res: fastify.FastifyReply<http.ServerResponse>


### PR DESCRIPTION
Hi, this PR will close #54 adding the value `true` to the sandbox csp directive to its allowed values.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
