### PR TITLE
fix(index): disabling one header disabled all headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = fp(function (fastify, opts, next) {
       const option = opts[middlewareName]
       const isDefault = config.defaultMiddleware.indexOf(middlewareName) !== -1
 
-      if (option === false) { return }
+      if (option === false) { continue }
 
       if (option != null) {
         if (option === true) {

--- a/test.js
+++ b/test.js
@@ -105,3 +105,35 @@ test('can add feature policy', (t) => {
     t.end()
   })
 })
+test('disabling one header does not disable the other headers', (t) => {
+  const fastify = Fastify()
+
+  fastify.register(helmet, {
+    frameguard: false
+  })
+
+  fastify.get('/', (request, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const notExpected = {
+      'x-frame-options': 'SAMEORIGIN'
+    }
+
+    const expected = {
+      'x-dns-prefetch-control': 'off',
+      'x-download-options': 'noopen',
+      'x-content-type-options': 'nosniff',
+      'x-xss-protection': '1; mode=block'
+    }
+
+    t.doesNotHave(res.headers, notExpected)
+    t.include(res.headers, expected)
+    t.end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

This fixes #79.

I replaced the `return` statement with a `continue` statement and the other security modules are no longer disabled when you pass `{ moduleName: false }` to `fastify-helmet`.

I also added tests to check that the header is removed and that the default security headers are still there.