### PR TITLE
Removes esModuleInterop from tsd and adds star import for helmet

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginCallback } from "fastify/types/plugin";
+import { FastifyPluginCallback } from "fastify";
 import * as helmet from "helmet";
 
 type FastifyHelmetOptions = Parameters<typeof helmet>[0];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
-import { FastifyPlugin } from "fastify";
-import helmet from "helmet";
+import { FastifyPluginCallback } from "fastify/types/plugin";
+import * as helmet from "helmet";
 
 type FastifyHelmetOptions = Parameters<typeof helmet>[0];
 
-export const fastifyHelmet: FastifyPlugin<NonNullable<FastifyHelmetOptions>>;
+export const fastifyHelmet: FastifyPluginCallback<NonNullable<FastifyHelmetOptions>>;
 
 export default fastifyHelmet;

--- a/package.json
+++ b/package.json
@@ -40,10 +40,5 @@
   "dependencies": {
     "fastify-plugin": "^2.1.1",
     "helmet": "^4.0.0"
-  },
-  "tsd": {
-    "compilerOptions": {
-      "esModuleInterop": true
-    }
   }
 }


### PR DESCRIPTION
Since this is a plugin consumed by final users if we use `esModuleInterop: true` (as was before this PR) we broke all builds for users that have it set to false. In fact `esModuleInterop` is always checked in the dependency tree by TS if `skipLibCheck` is not set to true: we need to be sure that our package works for both `esModuleInterop` configurations. 

On the other hand, Helmet doesn't use the "infamous triplet" (it still uses the old `export =` syntax), so we need to import it using `import * as helmet from 'helmet'` as it is a more conservative approach.

Fixes: https://github.com/fastify/fastify-helmet/issues/94

This PR can't be merged before this fix is published: https://github.com/fastify/fastify/pull/2555

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
