### PR TITLE
Uses import = require to import helmet types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginCallback } from "fastify/types/plugin";
+import { FastifyPluginCallback } from "fastify";
 import * as helmet from "helmet";
 
 type FastifyHelmetOptions = Parameters<typeof helmet>[0];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
-import { FastifyPlugin } from "fastify";
-import helmet from "helmet";
+import { FastifyPluginCallback } from "fastify/types/plugin";
+import * as helmet from "helmet";
 
 type FastifyHelmetOptions = Parameters<typeof helmet>[0];
 
-export const fastifyHelmet: FastifyPlugin<NonNullable<FastifyHelmetOptions>>;
+export const fastifyHelmet: FastifyPluginCallback<NonNullable<FastifyHelmetOptions>>;
 
 export default fastifyHelmet;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginCallback } from "fastify";
-import * as helmet from "helmet";
+import helmet = require("helmet");
 
 type FastifyHelmetOptions = Parameters<typeof helmet>[0];
 

--- a/package.json
+++ b/package.json
@@ -40,10 +40,5 @@
   "dependencies": {
     "fastify-plugin": "^2.1.1",
     "helmet": "^4.0.0"
-  },
-  "tsd": {
-    "compilerOptions": {
-      "esModuleInterop": true
-    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-helmet/pull/95#issuecomment-692415769

Since helmet is using `export =` the only way to make it work reliably with `esModuleInterop: true AND false` is to use `import = require`. This kind of import will tell TS that we are importing a `module.exports` namespace that could be callable:  in fact now TS follows the ESM spec and makes namespaces non-callable by default.

Side note: we need to test our typings, for all our plugins and fastify itself, against all possible combinations of TS configurations to prevent these issues in the future.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
