### PR TITLE
feat: csp nonce generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ retrieve the `nonces` through `reply.cspNonce`.
 
 Note: This feature is implemented inside this module. It is not a valid option or
       supported by helmet. If you need to use helmet feature only for csp nonce you
-      can follow the example [here](#csp-generation-helmet).
+      can follow the example [here](#example---generate-by-helmet).
 
 #### Example - Generate by options
 
@@ -72,7 +72,6 @@ fastify.get('/', function(request, reply) {
 })
 ```
 
-<a href="#csp-generation-helmet"></a>
 #### Example - Generate by helmet
 
 ```js

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ fastify.listen(3000, err => {
 
 ### Content-Security-Policy Nonce
 
+`fastify-helmet` provide a simple way for `csp nonces generation`. You can enable
+this behavior by passing `{ enableCSPNonces: true }` into the options. Then, you can 
+retrieve the `nonces` through `reply.cspNonce`.
+
+Example:
+
 ```js
 fastify.register(
   helmet,

--- a/README.md
+++ b/README.md
@@ -32,6 +32,37 @@ fastify.listen(3000, err => {
 })
 ```
 
+### Content-Security-Policy Nonce
+
+```js
+fastify.register(
+  helmet,
+  // enable csp nonces generation with default content-security-policy option
+  { enableCSPNonces: true }
+)
+
+fastify.register(
+  helmet,
+  // customize content security policy with nonce generation
+  { 
+    enableCSPNonces: true,
+    contentSecurityPolicy: {
+      directives: {
+        ...
+      }
+    }
+  }
+)
+
+fastify.get('/', function(request, reply) {
+  // retrieve script nonce
+  reply.cspNonce.script
+  // retrieve style nonce
+  reply.cspNonce.style
+})
+```
+
+
 ## How it works
 
 `fastify-helmet` is just a tiny wrapper around helmet that adds an `'onRequest'` hook.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ fastify.get('/', function(request, reply) {
 })
 ```
 
-<a href="#csp-generation-helmet">
+<a href="#csp-generation-helmet"></a>
 #### Example - Generate by helmet
 
 ```js

--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ fastify.listen(3000, err => {
 ### Content-Security-Policy Nonce
 
 `fastify-helmet` provide a simple way for `csp nonces generation`. You can enable
-this behavior by passing `{ enableCSPNonces: true }` into the options. Then, you can 
+this behavior by passing `{ enableCSPNonces: true }` into the options. Then, you can
 retrieve the `nonces` through `reply.cspNonce`.
 
-Example:
+Note: This feature is implemented inside this module. It is not a valid option or
+      supported by helmet. If you need to use helmet feature only for csp nonce you
+      can follow the example [here](#csp-generation-helmet).
+
+#### Example - Generate by options
 
 ```js
 fastify.register(
@@ -66,6 +70,41 @@ fastify.get('/', function(request, reply) {
   // retrieve style nonce
   reply.cspNonce.style
 })
+```
+
+<a href="#csp-generation-helmet">
+#### Example - Generate by helmet
+
+```js
+fastify.register(
+  helmet,
+  { 
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: [
+          function (req, res) {
+            // "res" here is actually "reply.raw" in fastify
+            res.scriptNonce = crypto.randomBytes(16).toString('hex')
+          }
+        ],
+        styleSrc: [
+          function (req, res) {
+            // "res" here is actually "reply.raw" in fastify
+            res.styleNonce = crypto.randomBytes(16).toString('hex')
+          }
+        ]
+      }
+    }
+  }
+)
+
+fastify.get('/', function(request, reply) {
+  // you can access the generated nonce by "reply.raw"
+  reply.raw.scriptNonce
+  reply.raw.styleNonce
+})
+
 ```
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,16 @@
 import { FastifyPluginCallback } from "fastify";
 import helmet = require("helmet");
 
-type FastifyHelmetOptions = Parameters<typeof helmet>[0];
+declare module 'fastify' {
+  interface FastifyReply {
+    cspNonce: {
+      script: string
+      style: string
+    }
+  }
+}
+
+type FastifyHelmetOptions = Parameters<typeof helmet>[0] & { enableCSPNonces?: boolean };
 
 export const fastifyHelmet: FastifyPluginCallback<NonNullable<FastifyHelmetOptions>>;
 

--- a/index.js
+++ b/index.js
@@ -2,13 +2,46 @@
 
 const fp = require('fastify-plugin')
 const helmet = require('helmet')
+const crypto = require('crypto')
 
 module.exports = fp(function (app, options, next) {
+  const enableCSPNonces = options.enableCSPNonces
+  // clear options as helmet will throw when any options is "true"
+  options.enableCSPNonces = undefined
+
   const middleware = helmet(options)
 
   app.addHook('onRequest', function (req, reply, next) {
     middleware(req.raw, reply.raw, next)
   })
+
+  if (enableCSPNonces) {
+    // outside onRequest hooks so that it can be reused in every route
+    const cspDirectives = options.contentSecurityPolicy ? options.contentSecurityPolicy.directives : helmet.contentSecurityPolicy.getDefaultDirectives()
+    const cspReportOnly = options.contentSecurityPolicy ? options.contentSecurityPolicy.reportOnly : undefined
+
+    app.decorateReply('cspNonce', null)
+    app.addHook('onRequest', function (req, reply, next) {
+      // create csp nonce
+      reply.cspNonce = {
+        script: crypto.randomBytes(16).toString('hex'),
+        style: crypto.randomBytes(16).toString('hex')
+      }
+
+      // push nonce to csp
+      // allow both script-src or scriptSrc syntax
+      const scriptKey = Array.isArray(cspDirectives['script-src']) ? 'script-src' : 'scriptSrc'
+      cspDirectives[scriptKey] = Array.isArray(cspDirectives.scriptSrc) ? cspDirectives.scriptSrc : []
+      cspDirectives[scriptKey].push('nonce-' + reply.cspNonce.script)
+      // allow both style-src or styleSrc syntax
+      const styleKey = Array.isArray(cspDirectives['style-src']) ? 'style-src' : 'styleSrc'
+      cspDirectives[styleKey] = Array.isArray(cspDirectives.styleSrc) ? cspDirectives.styleSrc : []
+      cspDirectives[styleKey].push('nonce-' + reply.cspNonce.style)
+
+      const cspMiddleware = helmet.contentSecurityPolicy({ directives: cspDirectives, reportOnly: cspReportOnly })
+      cspMiddleware(req.raw, reply.raw, next)
+    })
+  }
 
   next()
 }, {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,6 @@
-import fastifyHelmet from ".";
 import fastify from "fastify";
+import { expectType } from "tsd";
+import fastifyHelmet from ".";
 
 const app = fastify();
 
@@ -54,3 +55,21 @@ app.register(fastifyHelmet, {
   // noSniff: false,
   // xssFilter: false
 });
+
+
+app.register(fastifyHelmet, { enableCSPNonces: true });
+app.register(fastifyHelmet, { 
+  enableCSPNonces: true,
+  contentSecurityPolicy: {
+    directives: {
+      'directive-1': ['foo', 'bar']
+    },
+    reportOnly: true
+  },
+});
+app.get('/', function(request, reply) {
+  expectType<{
+    script: string
+    style: string
+  }>(reply.cspNonce)
+})


### PR DESCRIPTION
Resolve: #89 

This PR aims to simplify the usage for csp nonce generation with `fastify` and `helmet`.

Changes:
- introduce new option `enableCSPNonces`
- decorate `FastifyReply` with `cspNonce`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
