### PR TITLE
Add types for helmet.contentSecurityPolicy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginCallback } from "fastify";
-import helmet = require("helmet");
+import helmet from "helmet";
+import contentSecurityPolicy from "helmet/dist/middlewares/content-security-policy";
 
 declare module 'fastify' {
   interface FastifyReply {
@@ -12,6 +13,8 @@ declare module 'fastify' {
 
 type FastifyHelmetOptions = Parameters<typeof helmet>[0] & { enableCSPNonces?: boolean };
 
-export const fastifyHelmet: FastifyPluginCallback<NonNullable<FastifyHelmetOptions>>;
+export const fastifyHelmet: FastifyPluginCallback<NonNullable<FastifyHelmetOptions>> & {
+  contentSecurityPolicy: typeof contentSecurityPolicy;
+};
 
 export default fastifyHelmet;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 import { FastifyPluginCallback } from "fastify";
 import helmet from "helmet";
-import contentSecurityPolicy from "helmet/dist/middlewares/content-security-policy";
 
 declare module 'fastify' {
   interface FastifyReply {
@@ -14,7 +13,7 @@ declare module 'fastify' {
 type FastifyHelmetOptions = Parameters<typeof helmet>[0] & { enableCSPNonces?: boolean };
 
 export const fastifyHelmet: FastifyPluginCallback<NonNullable<FastifyHelmetOptions>> & {
-  contentSecurityPolicy: typeof contentSecurityPolicy;
+  contentSecurityPolicy: typeof helmet.contentSecurityPolicy;
 };
 
 export default fastifyHelmet;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginCallback } from "fastify";
-import helmet from "helmet";
+import helmet = require("helmet");
 
 declare module 'fastify' {
   interface FastifyReply {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,6 @@
 import fastify from "fastify";
 import { expectType } from "tsd";
+import helmet from "helmet";
 import fastifyHelmet from ".";
 
 const app = fastify();
@@ -73,3 +74,6 @@ app.get('/', function(request, reply) {
     style: string
   }>(reply.cspNonce)
 })
+
+const csp = fastifyHelmet.contentSecurityPolicy;
+expectType<typeof helmet.contentSecurityPolicy>(csp);


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      
Adding types for https://github.com/fastify/fastify-helmet/pull/109
