### PR TITLE
fix: checks if the `helmet` decorator exists before decorating `reply`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,10 @@ function helmetPlugin (fastify, options, next) {
 
   const isGlobal = typeof global === 'boolean' ? global : true
 
-  // We initialize the `helmet` reply decorator
-  fastify.decorateReply('helmet', null)
+  // We initialize the `helmet` reply decorator only if it does not already exists
+  if (!fastify.hasReplyDecorator('helmet')) {
+    fastify.decorateReply('helmet', null)
+  }
 
   // We will add the onRequest helmet middleware functions through the onRoute hook if needed
   fastify.addHook('onRoute', (routeOptions) => {

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -419,6 +419,42 @@ test('It should add the `helmet` reply decorator', async (t) => {
   t.has(response.headers, expected)
 })
 
+test('It should not throw when trying to add the `helmet` reply decorator if it already exists', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  // We decorate the reply with helmet to trigger the existing check
+  fastify.decorateReply('helmet', null)
+
+  await fastify.register(helmet, { global: false })
+
+  fastify.get('/', async (request, reply) => {
+    t.ok(reply.helmet)
+    t.not(reply.helmet, null)
+
+    await reply.helmet()
+    return { message: 'ok' }
+  })
+
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+
+  const expected = {
+    'x-dns-prefetch-control': 'off',
+    'x-frame-options': 'SAMEORIGIN',
+    'x-download-options': 'noopen',
+    'x-content-type-options': 'nosniff',
+    'x-xss-protection': '0'
+  }
+
+  t.has(response.headers, expected)
+})
+
 test('It should be able to pass custom options to the `helmet` reply decorator', async (t) => {
   t.plan(4)
 


### PR DESCRIPTION
Hello.

This PR aims to :
- checks if the `helmet` decorator exists before decorating `reply` (cf.: https://github.com/fastify/fastify-helmet/pull/166#issuecomment-1014531598)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
