### PR TITLE
feat: propagate `contentSecurityPolicy.useDefaults` through to helmet

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ fastify.get('/', function(request, reply) {
 
 ```
 
+### Disable Default `helmet` Directives
+
+By default, `helmet` will add [a default set of CSP directives](https://github.com/helmetjs/helmet/tree/main/middlewares/content-security-policy#content-security-policy-middleware) to the response.
+This behavior can be disabled by setting `useDefaults: false` in the `contentSecurityPolicy` configuration.
+
+```js
+fastify.register(
+  helmet,
+  {
+    contentSecurityPolicy: {
+      useDefaults: false,
+      directives: {
+        'default-src': ["'self'"]
+      }
+    }
+  }
+)
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -102,6 +102,9 @@ async function buildHelmetOnRoutes (request, reply, configuration, enableCSP) {
     const cspReportOnly = configuration.contentSecurityPolicy
       ? configuration.contentSecurityPolicy.reportOnly
       : undefined
+    const cspUseDefaults = configuration.contentSecurityPolicy
+      ? configuration.contentSecurityPolicy.useDefaults
+      : undefined
 
     // We get the csp nonce from the reply
     const { script: scriptCSPNonce, style: styleCSPNonce } = reply.cspNonce
@@ -119,7 +122,7 @@ async function buildHelmetOnRoutes (request, reply, configuration, enableCSP) {
     directives[styleKey] = Array.isArray(directives[styleKey]) ? [...directives[styleKey]] : []
     directives[styleKey].push(`'nonce-${styleCSPNonce}'`)
 
-    const contentSecurityPolicy = { directives, reportOnly: cspReportOnly }
+    const contentSecurityPolicy = { directives, reportOnly: cspReportOnly, useDefaults: cspUseDefaults }
     const mergedHelmetConfiguration = Object.assign(Object.create(null), configuration, { contentSecurityPolicy })
 
     helmet(mergedHelmetConfiguration)(request.raw, reply.raw, done)

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -37,7 +37,8 @@ appFour.register(fastifyHelmet, {
     directives: {
       'directive-1': ['foo', 'bar']
     },
-    reportOnly: true
+    reportOnly: true,
+    useDefaults: false
   },
   dnsPrefetchControl: {
     allow: true


### PR DESCRIPTION
This is a backport of #184 to the `fastify-helmet@8` major that's compatible with `fastify@3`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
