### PR TITLE
Replace deprecated context.config with routeConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function helmetPlugin (fastify, options) {
   })
 
   fastify.addHook('onRequest', async (request, reply) => {
-    const { helmet: routeOptions } = request.context.config
+    const { helmet: routeOptions } = request.routeConfig
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -50,7 +50,7 @@ async function helmetPlugin (fastify, options) {
   })
 
   fastify.addHook('onRequest', (request, reply, next) => {
-    const { helmet: routeOptions } = request.context.config
+    const { helmet: routeOptions } = request.routeConfig
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -685,7 +685,7 @@ test('It should not return a fastify `FST_ERR_REP_ALREADY_SENT - Reply already s
       }
 
       // We want to crash in the scope of this test
-      const crash = request.context.config.fail
+      const crash = request.routeConfig.fail
 
       Promise.resolve(crash).then((fail) => {
         if (fail === true) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This will remove the message:

> (node:17848) [FSTDEP012] FastifyDeprecation: Request#context property access is deprecated. Please use "Request#routeConfig" or "Request#routeSchema" instead for accessing Route settings. The "Request#context" will be removed in `fastify@5`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
