### PR TITLE
fix: min fastify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^18.0.0",
-    "fastify": "^4.5.3",
+    "fastify": "^4.7.0",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.0.0",


### PR DESCRIPTION
Follow up: https://github.com/fastify/fastify-helmet/pull/204

The `routeConfix` field has been shipped with fastify v4.7.0 