### PR TITLE
fix FastifyHelmetOptions type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,10 +27,10 @@ declare namespace fastifyHelmet {
     helmet?: Omit<FastifyHelmetOptions, 'global'> | false;
   }
 
-  export interface FastifyHelmetOptions extends NonNullable<HelmetOptions> {
+  export type FastifyHelmetOptions = {
     enableCSPNonces?: boolean,
     global?: boolean;
-  }
+  } & NonNullable<HelmetOptions>;
 
   export const fastifyHelmet: FastifyHelmet
   export { fastifyHelmet as default }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

A recent change to `HelmetOptions` made the current interface extension no longer work. Typescript complains about the error `An interface can only extend an object type or intersection of object types with statically known members.`. This PR fixes the problem by using a type intersection instead. Pulling in the latest 6.x.x version of helmet will show the issue.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
