### PR TITLE
fix: request route config deprecation - fixes #229

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ async function fastifyHelmet (fastify, options) {
 
   fastify.addHook('onRequest', async (request, reply) => {
     /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeConfig || request.context.config
+    const { helmet: routeOptions } = request.routeOptions.config || request.context.config
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -52,7 +52,7 @@ async function fastifyHelmet (fastify, options) {
 
   fastify.addHook('onRequest', (request, reply, next) => {
     /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeConfig || request.context.config
+    const { helmet: routeOptions } = request.routeOptions.config || request.context.config
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -685,7 +685,7 @@ test('It should not return a fastify `FST_ERR_REP_ALREADY_SENT - Reply already s
       }
 
       // We want to crash in the scope of this test
-      const crash = request.routeConfig.fail
+      const crash = request.routeOptions.config.fail
 
       Promise.resolve(crash).then((fail) => {
         if (fail === true) {


### PR DESCRIPTION
Recent change in Fastify 4.23.0 causes `request.routeConfig` deprecation warnings.

This PR fixes this by using the recommended `request.routeOptions.config` property.

Fixes #229 .

#### Checklist

- [ x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
