### PR TITLE
fix nestjs fastify platform warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,8 @@ async function fastifyHelmet (fastify, options) {
 
   fastify.addHook('onRequest', async (request, reply) => {
     /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeOptions.config ||
-    request.routeConfig ||
-    request.context.config
+    const { helmet: routeOptions } = request.routeOptions?.config ||
+    request.routeConfig
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -54,9 +53,8 @@ async function fastifyHelmet (fastify, options) {
 
   fastify.addHook('onRequest', (request, reply, next) => {
     /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeOptions.config ||
-    request.routeConfig ||
-    request.context.config
+    const { helmet: routeOptions } = request.routeOptions?.config ||
+    request.routeConfig
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ async function fastifyHelmet (fastify, options) {
 
   fastify.addHook('onRequest', async (request, reply) => {
     /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeOptions.config || request.context.config
+    const { helmet: routeOptions } = request.routeOptions.config ||
+    request.routeConfig ||
+    request.context.config
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -52,7 +54,9 @@ async function fastifyHelmet (fastify, options) {
 
   fastify.addHook('onRequest', (request, reply, next) => {
     /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeOptions.config || request.context.config
+    const { helmet: routeOptions } = request.routeOptions.config ||
+    request.routeConfig ||
+    request.context.config
 
     if (typeof routeOptions !== 'undefined') {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -685,7 +685,7 @@ test('It should not return a fastify `FST_ERR_REP_ALREADY_SENT - Reply already s
       }
 
       // We want to crash in the scope of this test
-      const crash = request.routeOptions.config.fail
+      const crash = request.routeOptions?.config?.fail || request.routeConfig.fail
 
       Promise.resolve(crash).then((fail) => {
         if (fail === true) {


### PR DESCRIPTION
fixed warn:
`
FastifyDeprecation: Request#context property access is deprecated. Please use "Request#routeConfig" or "Request#routeSchema" instead for accessing Route settings. The "Request#context" will be removed in fastify@5.
`

dep:
`"@nestjs/platform-fastify": "10.0.3",`



#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
