### PR TITLE
docs: fix return value with custom nonces example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,16 @@ fastify.register(
           function (req, res) {
             // "res" here is actually "reply.raw" in fastify
             res.scriptNonce = crypto.randomBytes(16).toString('hex')
+            // make sure to return nonce-... directive to helmet, so it can be sent in the headers
+            return `'nonce-${res.scriptNonce}'`
           }
         ],
         styleSrc: [
           function (req, res) {
             // "res" here is actually "reply.raw" in fastify
             res.styleNonce = crypto.randomBytes(16).toString('hex')
+            // make sure to return nonce-... directive to helmet, so it can be sent in the headers
+            return `'nonce-${res.styleNonce}'`
           }
         ]
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Documentation fix for custom nonces when generated by helmet itself

Just follow [the original docs](https://github.com/helmetjs/helmet/blob/main/README.md?plain=1#L116) and see that it actually `returns` nonce-... in the arrow fn,
[or source](https://github.com/helmetjs/helmet/blob/main/middlewares/content-security-policy/index.ts#L196) and see how `element(req, res)` gets joined into CSP header.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      

