### PR TITLE
fix: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,3 +1,0 @@
-disable-coverage: true
-plugin:
-  - "!@tapjs/typescript"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "standard --fix | snazzy",
     "test": "npm run lint && npm run unit && npm run typescript",
     "test:ci": "npm run lint && npm run coverage && npm run typescript",
-    "unit": "tap",
+    "unit": "c8 node --test",
     "unit:report": "npm run unit -- --coverage-report=html",
     "unit:verbose": "npm run unit -- -Rspec",
     "typescript": "tsd"
@@ -39,10 +39,10 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.3",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
-    "tap": "^21.0.0",
     "tsd": "^0.31.0"
   },
   "dependencies": {

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const stream = require('node:stream')
-const { test } = require('tap')
+const { test } = require('node:test')
 const fp = require('fastify-plugin')
 const Fastify = require('fastify')
 const helmet = require('..')
@@ -29,7 +29,15 @@ test('It should set the default headers', async (t) => {
     'x-xss-protection': '0'
   }
 
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-frame-options': response.headers['x-frame-options'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should not set the default headers when global is set to `false`', async (t) => {
@@ -55,7 +63,15 @@ test('It should not set the default headers when global is set to `false`', asyn
     'x-xss-protection': '0'
   }
 
-  t.notMatch(response.headers, notExpected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-frame-options': response.headers['x-frame-options'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.notDeepStrictEqual(actualResponseHeaders, notExpected)
 })
 
 test('It should set the default cross-domain-policy', async (t) => {
@@ -76,7 +92,10 @@ test('It should set the default cross-domain-policy', async (t) => {
     'x-permitted-cross-domain-policies': 'none'
   }
 
-  t.has(response.headers, expected)
+  t.assert.deepStrictEqual(
+    response.headers['x-permitted-cross-domain-policies'],
+    expected['x-permitted-cross-domain-policies']
+  )
 })
 
 test('It should be able to set cross-domain-policy', async (t) => {
@@ -100,7 +119,10 @@ test('It should be able to set cross-domain-policy', async (t) => {
     'x-permitted-cross-domain-policies': 'by-content-type'
   }
 
-  t.has(response.headers, expected)
+  t.assert.deepStrictEqual(
+    response.headers['x-permitted-cross-domain-policies'],
+    expected['x-permitted-cross-domain-policies']
+  )
 })
 
 test('It should not disable the other headers when disabling one header', async (t) => {
@@ -128,8 +150,15 @@ test('It should not disable the other headers when disabling one header', async 
     'x-xss-protection': '0'
   }
 
-  t.notMatch(response.headers, notExpected)
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.notDeepStrictEqual(actualResponseHeaders, notExpected)
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should be able to access default CSP directives through plugin export', async (t) => {
@@ -153,9 +182,15 @@ test('It should be able to access default CSP directives through plugin export',
     path: '/'
   })
 
-  const expected = { 'content-security-policy': 'default-src \'self\';base-uri \'self\';font-src \'self\' https: data:;form-action \'self\';frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests' }
+  const expected = {
+    'content-security-policy':
+      "default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+  }
 
-  t.has(response.headers, expected)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    expected['content-security-policy']
+  )
 })
 
 test('It should not set default directives when useDefaults is set to `false`', async (t) => {
@@ -166,7 +201,7 @@ test('It should not set default directives when useDefaults is set to `false`', 
     contentSecurityPolicy: {
       useDefaults: false,
       directives: {
-        defaultSrc: ['\'self\'']
+        defaultSrc: ["'self'"]
       }
     }
   })
@@ -180,9 +215,12 @@ test('It should not set default directives when useDefaults is set to `false`', 
     path: '/'
   })
 
-  const expected = { 'content-security-policy': 'default-src \'self\'' }
+  const expected = { 'content-security-policy': "default-src 'self'" }
 
-  t.has(response.headers, expected)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    expected['content-security-policy']
+  )
 })
 
 test('It should auto generate nonce per request', async (t) => {
@@ -194,7 +232,7 @@ test('It should auto generate nonce per request', async (t) => {
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply.cspNonce)
+    t.assert.ok(reply.cspNonce)
     reply.send(reply.cspNonce)
   })
 
@@ -202,14 +240,14 @@ test('It should auto generate nonce per request', async (t) => {
 
   response = await fastify.inject({ method: 'GET', path: '/' })
   const cspCache = response.json()
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
 
   response = await fastify.inject({ method: 'GET', path: '/' })
   const newCsp = response.json()
-  t.not(cspCache, newCsp)
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
+  t.assert.notDeepStrictEqual(cspCache, newCsp)
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
 })
 
 test('It should allow merging options for enableCSPNonces', async (t) => {
@@ -228,18 +266,19 @@ test('It should allow merging options for enableCSPNonces', async (t) => {
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply.cspNonce)
+    t.assert.ok(reply.cspNonce)
     reply.send(reply.cspNonce)
   })
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
   const cspCache = response.json()
 
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
-  t.has(response.headers, {
-    'content-security-policy': `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
-  })
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+  )
 })
 
 test('It should not set default directives when using enableCSPNonces and useDefaults is set to `false`', async (t) => {
@@ -251,26 +290,27 @@ test('It should not set default directives when using enableCSPNonces and useDef
     contentSecurityPolicy: {
       useDefaults: false,
       directives: {
-        defaultSrc: ['\'self\''],
-        scriptSrc: ['\'self\''],
-        styleSrc: ['\'self\'']
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'"]
       }
     }
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply.cspNonce)
+    t.assert.ok(reply.cspNonce)
     reply.send(reply.cspNonce)
   })
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
   const cspCache = response.json()
 
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
-  t.has(response.headers, {
-    'content-security-policy': `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}'`
-  })
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}'`
+  )
 })
 
 test('It should not stack nonce array in csp header', async (t) => {
@@ -289,27 +329,29 @@ test('It should not stack nonce array in csp header', async (t) => {
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply.cspNonce)
+    t.assert.ok(reply.cspNonce)
     reply.send(reply.cspNonce)
   })
 
   let response = await fastify.inject({ method: 'GET', path: '/' })
   let cspCache = response.json()
 
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
-  t.has(response.headers, {
-    'content-security-policy': `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
-  })
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+  )
 
   response = await fastify.inject({ method: 'GET', path: '/' })
   cspCache = response.json()
 
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
-  t.has(response.headers, {
-    'content-security-policy': `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
-  })
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+  )
 })
 
 test('It should access the correct options property', async (t) => {
@@ -327,18 +369,19 @@ test('It should access the correct options property', async (t) => {
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply.cspNonce)
+    t.assert.ok(reply.cspNonce)
     reply.send(reply.cspNonce)
   })
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
   const cspCache = response.json()
 
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
-  t.has(response.headers, {
-    'content-security-policy': `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'nonce-${cspCache.script}';style-src 'self' 'unsafe-inline' 'nonce-${cspCache.style}';default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
-  })
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'nonce-${cspCache.script}';style-src 'self' 'unsafe-inline' 'nonce-${cspCache.style}';default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+  )
 })
 
 test('It should not set script-src or style-src', async (t) => {
@@ -355,18 +398,19 @@ test('It should not set script-src or style-src', async (t) => {
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply.cspNonce)
+    t.assert.ok(reply.cspNonce)
     reply.send(reply.cspNonce)
   })
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
   const cspCache = response.json()
 
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
-  t.has(response.headers, {
-    'content-security-policy': `default-src 'self';script-src 'nonce-${cspCache.script}';style-src 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
-  })
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
+  t.assert.deepStrictEqual(
+    response.headers['content-security-policy'],
+    `default-src 'self';script-src 'nonce-${cspCache.script}';style-src 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+  )
 })
 
 test('It should add hooks correctly', async (t) => {
@@ -380,19 +424,31 @@ test('It should add hooks correctly', async (t) => {
 
   await fastify.register(helmet, { global: true })
 
-  fastify.get('/one', {
-    onRequest: [
-      async (request, reply) => { reply.header('x-fastify-test-one', 'ok') }
-    ]
-  }, (request, reply) => {
-    return { message: 'one' }
-  })
+  fastify.get(
+    '/one',
+    {
+      onRequest: [
+        async (request, reply) => {
+          reply.header('x-fastify-test-one', 'ok')
+        }
+      ]
+    },
+    (request, reply) => {
+      return { message: 'one' }
+    }
+  )
 
-  fastify.get('/two', {
-    onRequest: async (request, reply) => { reply.header('x-fastify-test-two', 'ok') }
-  }, (request, reply) => {
-    return { message: 'two' }
-  })
+  fastify.get(
+    '/two',
+    {
+      onRequest: async (request, reply) => {
+        reply.header('x-fastify-test-two', 'ok')
+      }
+    },
+    (request, reply) => {
+      return { message: 'two' }
+    }
+  )
 
   fastify.get('/three', { onRequest: async () => {} }, (request, reply) => {
     return { message: 'three' }
@@ -406,43 +462,73 @@ test('It should add hooks correctly', async (t) => {
     'x-xss-protection': '0'
   }
 
-  await fastify.inject({
-    path: '/one',
-    method: 'GET'
-  }).then((response) => {
-    t.equal(response.statusCode, 200)
-    t.equal(response.headers['x-fastify-global-test'], 'ok')
-    t.equal(response.headers['x-fastify-test-one'], 'ok')
-    t.has(response.headers, expected)
-    t.equal(JSON.parse(response.payload).message, 'one')
-  }).catch((err) => {
-    t.error(err)
-  })
+  await fastify
+    .inject({
+      path: '/one',
+      method: 'GET'
+    })
+    .then((response) => {
+      const actualResponseHeaders = {
+        'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+        'x-frame-options': response.headers['x-frame-options'],
+        'x-download-options': response.headers['x-download-options'],
+        'x-content-type-options': response.headers['x-content-type-options'],
+        'x-xss-protection': response.headers['x-xss-protection']
+      }
+      t.assert.deepStrictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(response.headers['x-fastify-global-test'], 'ok')
+      t.assert.deepStrictEqual(response.headers['x-fastify-test-one'], 'ok')
+      t.assert.deepStrictEqual(actualResponseHeaders, expected)
+      t.assert.deepStrictEqual(JSON.parse(response.payload).message, 'one')
+    })
+    .catch((err) => {
+      t.assert.ifError(err)
+    })
 
-  await fastify.inject({
-    path: '/two',
-    method: 'GET'
-  }).then((response) => {
-    t.equal(response.statusCode, 200)
-    t.equal(response.headers['x-fastify-global-test'], 'ok')
-    t.equal(response.headers['x-fastify-test-two'], 'ok')
-    t.has(response.headers, expected)
-    t.equal(JSON.parse(response.payload).message, 'two')
-  }).catch((err) => {
-    t.error(err)
-  })
+  await fastify
+    .inject({
+      path: '/two',
+      method: 'GET'
+    })
+    .then((response) => {
+      const actualResponseHeaders = {
+        'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+        'x-frame-options': response.headers['x-frame-options'],
+        'x-download-options': response.headers['x-download-options'],
+        'x-content-type-options': response.headers['x-content-type-options'],
+        'x-xss-protection': response.headers['x-xss-protection']
+      }
+      t.assert.deepStrictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(response.headers['x-fastify-global-test'], 'ok')
+      t.assert.deepStrictEqual(response.headers['x-fastify-test-two'], 'ok')
+      t.assert.deepStrictEqual(actualResponseHeaders, expected)
+      t.assert.deepStrictEqual(JSON.parse(response.payload).message, 'two')
+    })
+    .catch((err) => {
+      t.error(err)
+    })
 
-  await fastify.inject({
-    path: '/three',
-    method: 'GET'
-  }).then((response) => {
-    t.equal(response.statusCode, 200)
-    t.equal(response.headers['x-fastify-global-test'], 'ok')
-    t.has(response.headers, expected)
-    t.equal(JSON.parse(response.payload).message, 'three')
-  }).catch((err) => {
-    t.error(err)
-  })
+  await fastify
+    .inject({
+      path: '/three',
+      method: 'GET'
+    })
+    .then((response) => {
+      const actualResponseHeaders = {
+        'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+        'x-frame-options': response.headers['x-frame-options'],
+        'x-download-options': response.headers['x-download-options'],
+        'x-content-type-options': response.headers['x-content-type-options'],
+        'x-xss-protection': response.headers['x-xss-protection']
+      }
+      t.assert.deepStrictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(response.headers['x-fastify-global-test'], 'ok')
+      t.assert.deepStrictEqual(actualResponseHeaders, expected)
+      t.assert.deepStrictEqual(JSON.parse(response.payload).message, 'three')
+    })
+    .catch((err) => {
+      t.assert.ifError(err)
+    })
 })
 
 test('It should add the `helmet` reply decorator', async (t) => {
@@ -452,8 +538,8 @@ test('It should add the `helmet` reply decorator', async (t) => {
   await fastify.register(helmet, { global: false })
 
   fastify.get('/', async (request, reply) => {
-    t.ok(reply.helmet)
-    t.not(reply.helmet, null)
+    t.assert.ok(reply.helmet)
+    t.assert.notStrictEqual(reply.helmet, null)
 
     await reply.helmet()
     return { message: 'ok' }
@@ -463,7 +549,6 @@ test('It should add the `helmet` reply decorator', async (t) => {
     method: 'GET',
     path: '/'
   })
-
   const expected = {
     'x-dns-prefetch-control': 'off',
     'x-frame-options': 'SAMEORIGIN',
@@ -472,7 +557,15 @@ test('It should add the `helmet` reply decorator', async (t) => {
     'x-xss-protection': '0'
   }
 
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-frame-options': response.headers['x-frame-options'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should not throw when trying to add the `helmet` and `cspNonce` reply decorators if they already exist', async (t) => {
@@ -487,10 +580,10 @@ test('It should not throw when trying to add the `helmet` and `cspNonce` reply d
   await fastify.register(helmet, { enableCSPNonces: true, global: true })
 
   fastify.get('/', async (request, reply) => {
-    t.ok(reply.helmet)
-    t.not(reply.helmet, null)
-    t.ok(reply.cspNonce)
-    t.not(reply.cspNonce, null)
+    t.assert.ok(reply.helmet)
+    t.assert.notDeepStrictEqual(reply.helmet, null)
+    t.assert.ok(reply.cspNonce)
+    t.assert.notDeepStrictEqual(reply.cspNonce, null)
 
     reply.send(reply.cspNonce)
   })
@@ -501,8 +594,8 @@ test('It should not throw when trying to add the `helmet` and `cspNonce` reply d
   })
 
   const cspCache = response.json()
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
 
   const expected = {
     'x-dns-prefetch-control': 'off',
@@ -512,7 +605,15 @@ test('It should not throw when trying to add the `helmet` and `cspNonce` reply d
     'x-xss-protection': '0'
   }
 
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-frame-options': response.headers['x-frame-options'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should be able to pass custom options to the `helmet` reply decorator', async (t) => {
@@ -522,8 +623,8 @@ test('It should be able to pass custom options to the `helmet` reply decorator',
   await fastify.register(helmet, { global: false })
 
   fastify.get('/', async (request, reply) => {
-    t.ok(reply.helmet)
-    t.not(reply.helmet, null)
+    t.assert.ok(reply.helmet)
+    t.assert.notDeepStrictEqual(reply.helmet, null)
 
     await reply.helmet({ frameguard: false })
     return { message: 'ok' }
@@ -545,8 +646,19 @@ test('It should be able to pass custom options to the `helmet` reply decorator',
     'x-frame-options': 'SAMEORIGIN'
   }
 
-  t.notMatch(response.headers, notExpected)
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  const actualNotExpectedHeaders = {
+    'x-frame-options': response.headers['x-frame-options']
+  }
+
+  t.assert.notDeepStrictEqual(actualNotExpectedHeaders, notExpected)
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should be able to conditionally apply the middlewares through the `helmet` reply decorator', async (t) => {
@@ -558,8 +670,8 @@ test('It should be able to conditionally apply the middlewares through the `helm
   fastify.get('/:condition', { helmet: false }, async (request, reply) => {
     const { condition } = request.params
 
-    t.ok(reply.helmet)
-    t.not(reply.helmet, null)
+    t.assert.ok(reply.helmet)
+    t.assert.notDeepStrictEqual(reply.helmet, null)
 
     if (condition !== 'frameguard') {
       await reply.helmet({ frameguard: false })
@@ -586,9 +698,20 @@ test('It should be able to conditionally apply the middlewares through the `helm
       path: '/no-frameguard'
     })
 
-    t.equal(response.statusCode, 200)
-    t.notMatch(response.headers, maybeExpected)
-    t.has(response.headers, expected)
+    const actualResponseHeaders = {
+      'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+      'x-download-options': response.headers['x-download-options'],
+      'x-content-type-options': response.headers['x-content-type-options'],
+      'x-xss-protection': response.headers['x-xss-protection']
+    }
+
+    const actualMaybeExpectedHeaders = {
+      'x-frame-options': response.headers['x-frame-options']
+    }
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.notDeepStrictEqual(actualMaybeExpectedHeaders, maybeExpected)
+    t.assert.deepStrictEqual(actualResponseHeaders, expected)
   }
 
   const response = await fastify.inject({
@@ -596,9 +719,20 @@ test('It should be able to conditionally apply the middlewares through the `helm
     path: '/frameguard'
   })
 
-  t.equal(response.statusCode, 200)
-  t.has(response.headers, maybeExpected)
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  const actualMaybeExpectedHeaders = {
+    'x-frame-options': response.headers['x-frame-options']
+  }
+
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(actualMaybeExpectedHeaders, maybeExpected)
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should apply helmet headers when returning error messages', async (t) => {
@@ -607,17 +741,20 @@ test('It should apply helmet headers when returning error messages', async (t) =
   const fastify = Fastify()
   await fastify.register(helmet, { enableCSPNonces: true })
 
-  fastify.get('/', {
-    onRequest: async (request, reply) => {
-      reply.code(401)
-      reply.send({ message: 'Unauthorized' })
+  fastify.get(
+    '/',
+    {
+      onRequest: async (request, reply) => {
+        reply.code(401)
+        reply.send({ message: 'Unauthorized' })
+      }
+    },
+    async (request, reply) => {
+      return { message: 'ok' }
     }
-  }, async (request, reply) => {
-    return { message: 'ok' }
-  })
+  )
 
-  fastify.get('/error-handler', {
-  }, async (request, reply) => {
+  fastify.get('/error-handler', {}, async (request, reply) => {
     return Promise.reject(new Error('error handler triggered'))
   })
 
@@ -635,8 +772,16 @@ test('It should apply helmet headers when returning error messages', async (t) =
       path: '/'
     })
 
-    t.equal(response.statusCode, 401)
-    t.has(response.headers, expected)
+    const actualResponseHeaders = {
+      'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+      'x-frame-options': response.headers['x-frame-options'],
+      'x-download-options': response.headers['x-download-options'],
+      'x-content-type-options': response.headers['x-content-type-options'],
+      'x-xss-protection': response.headers['x-xss-protection']
+    }
+
+    t.assert.deepStrictEqual(response.statusCode, 401)
+    t.assert.deepStrictEqual(actualResponseHeaders, expected)
   }
 
   {
@@ -645,8 +790,16 @@ test('It should apply helmet headers when returning error messages', async (t) =
       path: '/error-handler'
     })
 
-    t.equal(response.statusCode, 500)
-    t.has(response.headers, expected)
+    const actualResponseHeaders = {
+      'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+      'x-frame-options': response.headers['x-frame-options'],
+      'x-download-options': response.headers['x-download-options'],
+      'x-content-type-options': response.headers['x-content-type-options'],
+      'x-xss-protection': response.headers['x-xss-protection']
+    }
+
+    t.assert.deepStrictEqual(response.statusCode, 500)
+    t.assert.deepStrictEqual(actualResponseHeaders, expected)
   }
 
   {
@@ -655,8 +808,16 @@ test('It should apply helmet headers when returning error messages', async (t) =
       path: '/404-route'
     })
 
-    t.equal(response.statusCode, 404)
-    t.has(response.headers, expected)
+    const actualResponseHeaders = {
+      'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+      'x-frame-options': response.headers['x-frame-options'],
+      'x-download-options': response.headers['x-download-options'],
+      'x-content-type-options': response.headers['x-content-type-options'],
+      'x-xss-protection': response.headers['x-xss-protection']
+    }
+
+    t.assert.deepStrictEqual(response.statusCode, 404)
+    t.assert.deepStrictEqual(actualResponseHeaders, expected)
   }
 })
 
@@ -676,34 +837,46 @@ test('It should not return a fastify `FST_ERR_REP_ALREADY_SENT - Reply already s
   const fastify = Fastify({ logger: { level: 'info', stream: destination } })
 
   await fastify.register(helmet)
-  await fastify.register(fp(async (instance, options) => {
-    instance.addHook('onRequest', async (request, reply) => {
-      const unauthorized = new Error('Unauthorized')
+  await fastify.register(
+    fp(
+      async (instance, options) => {
+        instance.addHook('onRequest', async (request, reply) => {
+          const unauthorized = new Error('Unauthorized')
 
-      const errorResponse = (err) => {
-        return { error: err.message }
+          const errorResponse = (err) => {
+            return { error: err.message }
+          }
+
+          // We want to crash in the scope of this test
+          const crash =
+            request.routeOptions?.config?.fail || request.routeConfig.fail
+
+          Promise.resolve(crash)
+            .then((fail) => {
+              if (fail === true) {
+                reply.code(401)
+                reply.send(errorResponse(unauthorized))
+                return reply
+              }
+            })
+            .catch(() => undefined)
+        })
+      },
+      {
+        name: 'regression-plugin-test'
       }
+    )
+  )
 
-      // We want to crash in the scope of this test
-      const crash = request.routeOptions?.config?.fail || request.routeConfig.fail
-
-      Promise.resolve(crash).then((fail) => {
-        if (fail === true) {
-          reply.code(401)
-          reply.send(errorResponse(unauthorized))
-          return reply
-        }
-      }).catch(() => undefined)
-    })
-  }, {
-    name: 'regression-plugin-test'
-  }))
-
-  fastify.get('/fail', {
-    config: { fail: true }
-  }, async (request, reply) => {
-    return { message: 'unreachable' }
-  })
+  fastify.get(
+    '/fail',
+    {
+      config: { fail: true }
+    },
+    async (request, reply) => {
+      return { message: 'unreachable' }
+    }
+  )
 
   const expected = {
     'x-dns-prefetch-control': 'off',
@@ -718,7 +891,17 @@ test('It should not return a fastify `FST_ERR_REP_ALREADY_SENT - Reply already s
     path: '/fail'
   })
 
-  const failure = logs.find((entry) => entry.err && entry.err.statusCode === 500)
+  const failure = logs.find(
+    (entry) => entry.err && entry.err.statusCode === 500
+  )
+
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-frame-options': response.headers['x-frame-options'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
 
   if (failure) {
     t.not(failure.err.message, 'Reply was already sent.')
@@ -728,12 +911,15 @@ test('It should not return a fastify `FST_ERR_REP_ALREADY_SENT - Reply already s
     t.not(failure.msg, 'Reply already sent')
   }
 
-  t.equal(failure, undefined)
+  t.assert.deepStrictEqual(failure, undefined)
 
-  t.equal(response.statusCode, 401)
-  t.has(response.headers, expected)
-  t.equal(JSON.parse(response.payload).error, 'Unauthorized')
-  t.not(JSON.parse(response.payload).message, 'unreachable')
+  t.assert.deepStrictEqual(response.statusCode, 401)
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
+  t.assert.deepStrictEqual(JSON.parse(response.payload).error, 'Unauthorized')
+  t.assert.notDeepStrictEqual(
+    JSON.parse(response.payload).message,
+    'unreachable'
+  )
 })
 
 test('It should forward `helmet` errors to `fastify-helmet`', async (t) => {
@@ -765,12 +951,20 @@ test('It should forward `helmet` errors to `fastify-helmet`', async (t) => {
     path: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-frame-options': response.headers['x-frame-options'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.deepStrictEqual(response.statusCode, 500)
+  t.assert.deepStrictEqual(
     JSON.parse(response.payload).message,
     'Content-Security-Policy received an invalid directive value for "default-src"'
   )
-  t.notMatch(response.headers, notExpected)
+  t.assert.notDeepStrictEqual(actualResponseHeaders, notExpected)
 })
 
 test('It should be able to catch `helmet` errors with a fastify `onError` hook', async (t) => {
@@ -789,8 +983,8 @@ test('It should be able to catch `helmet` errors with a fastify `onError` hook',
 
   fastify.addHook('onError', async (request, reply, error) => {
     if (error) {
-      t.ok(error)
       errorDetected.push(error)
+      t.assert.ok(error)
     }
   })
 
@@ -806,21 +1000,29 @@ test('It should be able to catch `helmet` errors with a fastify `onError` hook',
     'x-xss-protection': '0'
   }
 
-  t.equal(errorDetected.length, 0)
+  t.assert.deepStrictEqual(errorDetected.length, 0)
 
   const response = await fastify.inject({
     method: 'GET',
     path: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-frame-options': response.headers['x-frame-options'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.deepStrictEqual(response.statusCode, 500)
+  t.assert.deepStrictEqual(
     JSON.parse(response.payload).message,
     'Content-Security-Policy received an invalid directive value for "default-src"'
   )
-  t.notMatch(response.headers, notExpected)
-  t.equal(errorDetected.length, 1)
-  t.equal(
+  t.assert.notDeepStrictEqual(actualResponseHeaders, notExpected)
+  t.assert.deepStrictEqual(errorDetected.length, 1)
+  t.assert.deepStrictEqual(
     errorDetected[0].message,
     'Content-Security-Policy received an invalid directive value for "default-src"'
   )

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const helmet = require('..')
 
@@ -30,8 +30,18 @@ test('It should apply route specific helmet options over the global options', as
     'x-xss-protection': '0'
   }
 
-  t.notMatch(response.headers, notExpected)
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.notDeepStrictEqual(
+    response.headers['x-frame-options'],
+    notExpected['x-frame-options']
+  )
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should disable helmet on specific route when route `helmet` option is set to `false`', async (t) => {
@@ -56,23 +66,44 @@ test('It should disable helmet on specific route when route `helmet` option is s
     'x-xss-protection': '0'
   }
 
-  await fastify.inject({
-    method: 'GET',
-    path: '/disabled'
-  }).then((response) => {
-    t.notMatch(response.headers, helmetHeaders)
-  }).catch((err) => {
-    t.error(err)
-  })
+  await fastify
+    .inject({
+      method: 'GET',
+      path: '/disabled'
+    })
+    .then((response) => {
+      const actualResponseHeaders = {
+        'x-frame-options': response.headers['x-frame-options'],
+        'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+        'x-download-options': response.headers['x-download-options'],
+        'x-content-type-options': response.headers['x-content-type-options'],
+        'x-xss-protection': response.headers['x-xss-protection']
+      }
 
-  await fastify.inject({
-    method: 'GET',
-    path: '/enabled'
-  }).then((response) => {
-    t.has(response.headers, helmetHeaders)
-  }).catch((err) => {
-    t.error(err)
-  })
+      t.assert.notDeepStrictEqual(actualResponseHeaders, helmetHeaders)
+    })
+    .catch((err) => {
+      t.assert.fail(err)
+    })
+
+  await fastify
+    .inject({
+      method: 'GET',
+      path: '/enabled'
+    })
+    .then((response) => {
+      const actualResponseHeaders = {
+        'x-frame-options': response.headers['x-frame-options'],
+        'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+        'x-download-options': response.headers['x-download-options'],
+        'x-content-type-options': response.headers['x-content-type-options'],
+        'x-xss-protection': response.headers['x-xss-protection']
+      }
+      t.assert.deepStrictEqual(actualResponseHeaders, helmetHeaders)
+    })
+    .catch((err) => {
+      t.assert.fail(err)
+    })
 })
 
 test('It should add CSPNonce decorator and hooks when route `enableCSPNonces` option is set to `true`', async (t) => {
@@ -91,23 +122,32 @@ test('It should add CSPNonce decorator and hooks when route `enableCSPNonces` op
     }
   })
 
-  fastify.get('/', {
-    helmet: {
-      enableCSPNonces: true
+  fastify.get(
+    '/',
+    {
+      helmet: {
+        enableCSPNonces: true
+      }
+    },
+    (request, reply) => {
+      t.assert.ok(reply.cspNonce)
+      reply.send(reply.cspNonce)
     }
-  }, (request, reply) => {
-    t.ok(reply.cspNonce)
-    reply.send(reply.cspNonce)
-  })
+  )
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
   const cspCache = response.json()
 
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
-  t.has(response.headers, {
+  const expected = {
     'content-security-policy': `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'nonce-${cspCache.script}';style-src 'self' 'unsafe-inline' 'nonce-${cspCache.style}';default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
-  })
+  }
+
+  const actualResponseHeaders = {
+    'content-security-policy': response.headers['content-security-policy']
+  }
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should add CSPNonce decorator and hooks with default options when route `enableCSPNonces` option is set to `true`', async (t) => {
@@ -121,18 +161,22 @@ test('It should add CSPNonce decorator and hooks with default options when route
   })
 
   fastify.get('/no-csp', (request, reply) => {
-    t.equal(reply.cspNonce, null)
+    t.assert.equal(reply.cspNonce, null)
     reply.send({ message: 'no csp' })
   })
 
-  fastify.get('/with-csp', {
-    helmet: {
-      enableCSPNonces: true
+  fastify.get(
+    '/with-csp',
+    {
+      helmet: {
+        enableCSPNonces: true
+      }
+    },
+    (request, reply) => {
+      t.assert.ok(reply.cspNonce)
+      reply.send(reply.cspNonce)
     }
-  }, (request, reply) => {
-    t.ok(reply.cspNonce)
-    reply.send(reply.cspNonce)
-  })
+  )
 
   fastify.inject({
     method: 'GET',
@@ -143,14 +187,14 @@ test('It should add CSPNonce decorator and hooks with default options when route
 
   response = await fastify.inject({ method: 'GET', path: '/with-csp' })
   const cspCache = response.json()
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
 
   response = await fastify.inject({ method: 'GET', path: '/with-csp' })
   const newCsp = response.json()
-  t.not(cspCache, newCsp)
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
+  t.assert.notEqual(cspCache, newCsp)
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
 })
 
 test('It should not add CSPNonce decorator when route `enableCSPNonces` option is set to `false`', async (t) => {
@@ -164,14 +208,18 @@ test('It should not add CSPNonce decorator when route `enableCSPNonces` option i
   })
 
   fastify.get('/with-csp', (request, reply) => {
-    t.ok(reply.cspNonce)
+    t.assert.ok(reply.cspNonce)
     reply.send(reply.cspNonce)
   })
 
-  fastify.get('/no-csp', { helmet: { enableCSPNonces: false } }, (request, reply) => {
-    t.equal(reply.cspNonce, null)
-    reply.send({ message: 'no csp' })
-  })
+  fastify.get(
+    '/no-csp',
+    { helmet: { enableCSPNonces: false } },
+    (request, reply) => {
+      t.assert.equal(reply.cspNonce, null)
+      reply.send({ message: 'no csp' })
+    }
+  )
 
   fastify.inject({
     method: 'GET',
@@ -182,14 +230,14 @@ test('It should not add CSPNonce decorator when route `enableCSPNonces` option i
 
   response = await fastify.inject({ method: 'GET', path: '/with-csp' })
   const cspCache = response.json()
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
 
   response = await fastify.inject({ method: 'GET', path: '/with-csp' })
   const newCsp = response.json()
-  t.not(cspCache, newCsp)
-  t.ok(cspCache.script)
-  t.ok(cspCache.style)
+  t.assert.notEqual(cspCache, newCsp)
+  t.assert.ok(cspCache.script)
+  t.assert.ok(cspCache.style)
 })
 
 test('It should not set default directives when route useDefaults is set to `false`', async (t) => {
@@ -201,31 +249,41 @@ test('It should not set default directives when route useDefaults is set to `fal
     global: false,
     enableCSPNonces: false,
     contentSecurityPolicy: {
-      directives: {
-      }
+      directives: {}
     }
   })
 
-  fastify.get('/', {
-    helmet: {
-      contentSecurityPolicy: {
-        useDefaults: false,
-        directives: {
-          'default-src': ["'self'"],
-          'script-src': ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
-          'style-src': ["'self'", "'unsafe-inline'"]
+  fastify.get(
+    '/',
+    {
+      helmet: {
+        contentSecurityPolicy: {
+          useDefaults: false,
+          directives: {
+            'default-src': ["'self'"],
+            'script-src': ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
+            'style-src': ["'self'", "'unsafe-inline'"]
+          }
         }
       }
+    },
+    (request, reply) => {
+      reply.send({ hello: 'world' })
     }
-  }, (request, reply) => {
-    reply.send({ hello: 'world' })
-  })
+  )
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
 
-  t.has(response.headers, {
-    'content-security-policy': "default-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline';style-src 'self' 'unsafe-inline'"
-  })
+  const expected = {
+    'content-security-policy':
+      "default-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline';style-src 'self' 'unsafe-inline'"
+  }
+
+  const actualResponseHeaders = {
+    'content-security-policy': response.headers['content-security-policy']
+  }
+
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should be able to conditionally apply the middlewares through the `helmet` reply decorator', async (t) => {
@@ -237,8 +295,8 @@ test('It should be able to conditionally apply the middlewares through the `helm
   fastify.get('/:condition', async (request, reply) => {
     const { condition } = request.params
 
-    t.ok(reply.helmet)
-    t.not(reply.helmet, null)
+    t.assert.ok(reply.helmet)
+    t.assert.notEqual(reply.helmet, null)
 
     if (condition !== 'frameguard') {
       await reply.helmet({ frameguard: false })
@@ -265,9 +323,19 @@ test('It should be able to conditionally apply the middlewares through the `helm
       path: '/no-frameguard'
     })
 
-    t.equal(response.statusCode, 200)
-    t.notMatch(response.headers, maybeExpected)
-    t.has(response.headers, expected)
+    const actualResponseHeaders = {
+      'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+      'x-download-options': response.headers['x-download-options'],
+      'x-content-type-options': response.headers['x-content-type-options'],
+      'x-xss-protection': response.headers['x-xss-protection']
+    }
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.notDeepStrictEqual(
+      response.headers['x-frame-options'],
+      maybeExpected['x-frame-options']
+    )
+    t.assert.deepStrictEqual(actualResponseHeaders, expected)
   }
 
   const response = await fastify.inject({
@@ -275,9 +343,19 @@ test('It should be able to conditionally apply the middlewares through the `helm
     path: '/frameguard'
   })
 
-  t.equal(response.statusCode, 200)
-  t.has(response.headers, maybeExpected)
-  t.has(response.headers, expected)
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(
+    response.headers['x-frame-options'],
+    maybeExpected['x-frame-options']
+  )
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
 test('It should throw an error when route specific helmet options are of an invalid type', async (t) => {
@@ -291,8 +369,11 @@ test('It should throw an error when route specific helmet options are of an inva
       return { message: 'ok' }
     })
   } catch (error) {
-    t.ok(error)
-    t.equal(error.message, 'Unknown value for route helmet configuration')
+    t.assert.ok(error)
+    t.assert.equal(
+      error.message,
+      'Unknown value for route helmet configuration'
+    )
   }
 })
 
@@ -314,17 +395,21 @@ test('It should forward `helmet` reply decorator and route specific errors to `f
     return { message: 'ok' }
   })
 
-  fastify.get('/helmet-route-configuration-error', {
-    helmet: {
-      contentSecurityPolicy: {
-        directives: {
-          defaultSrc: ["'self'", () => 'bad;value']
+  fastify.get(
+    '/helmet-route-configuration-error',
+    {
+      helmet: {
+        contentSecurityPolicy: {
+          directives: {
+            defaultSrc: ["'self'", () => 'bad;value']
+          }
         }
       }
+    },
+    async (request, reply) => {
+      return { message: 'ok' }
     }
-  }, async (request, reply) => {
-    return { message: 'ok' }
-  })
+  )
 
   const notExpected = {
     'x-dns-prefetch-control': 'off',
@@ -340,12 +425,19 @@ test('It should forward `helmet` reply decorator and route specific errors to `f
       path: '/helmet-reply-decorator-error'
     })
 
-    t.equal(response.statusCode, 500)
-    t.equal(
+    const actualResponseHeaders = {
+      'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+      'x-download-options': response.headers['x-download-options'],
+      'x-content-type-options': response.headers['x-content-type-options'],
+      'x-xss-protection': response.headers['x-xss-protection']
+    }
+
+    t.assert.equal(response.statusCode, 500)
+    t.assert.equal(
       JSON.parse(response.payload).message,
       'Content-Security-Policy received an invalid directive value for "default-src"'
     )
-    t.notMatch(response.headers, notExpected)
+    t.assert.notDeepStrictEqual(actualResponseHeaders, notExpected)
   }
 
   const response = await fastify.inject({
@@ -353,10 +445,17 @@ test('It should forward `helmet` reply decorator and route specific errors to `f
     path: '/helmet-route-configuration-error'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(
+  const actualResponseHeaders = {
+    'x-dns-prefetch-control': response.headers['x-dns-prefetch-control'],
+    'x-download-options': response.headers['x-download-options'],
+    'x-content-type-options': response.headers['x-content-type-options'],
+    'x-xss-protection': response.headers['x-xss-protection']
+  }
+
+  t.assert.equal(response.statusCode, 500)
+  t.assert.equal(
     JSON.parse(response.payload).message,
     'Content-Security-Policy received an invalid directive value for "default-src"'
   )
-  t.notMatch(response.headers, notExpected)
+  t.assert.notDeepStrictEqual(actualResponseHeaders, notExpected)
 })


### PR DESCRIPTION
#### Checklist

This PR removes tap and adds node:test and c8

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
