### PR TITLE
chore: add c8 flag for 100 % code coverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,8 @@ async function fastifyHelmet (fastify, options) {
   })
 
   fastify.addHook('onRequest', async (request, reply) => {
-    /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeOptions?.config ||
-    request.routeConfig
+    /* c8 ignore next */
+    const { helmet: routeOptions } = request.routeOptions?.config || request.routeConfig
 
     if (routeOptions !== undefined) {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -52,9 +51,8 @@ async function fastifyHelmet (fastify, options) {
   })
 
   fastify.addHook('onRequest', (request, reply, next) => {
-    /* istanbul ignore next */
-    const { helmet: routeOptions } = request.routeOptions?.config ||
-    request.routeConfig
+    /* c8 ignore next */
+    const { helmet: routeOptions } = request.routeOptions?.config || request.routeConfig
 
     if (routeOptions !== undefined) {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "standard --fix | snazzy",
     "test": "npm run lint && npm run unit && npm run typescript",
     "test:ci": "npm run lint && npm run coverage && npm run typescript",
-    "unit": "c8 node --test",
+    "unit": "c8 --100 node --test",
     "unit:report": "npm run unit -- --coverage-report=html",
     "unit:verbose": "npm run unit -- -Rspec",
     "typescript": "tsd"


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
