### PR TITLE
Respect route-level `contentSecurityPolicy: false` setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ async function replyDecorators (request, reply, configuration, enableCSP) {
 }
 
 async function buildHelmetOnRoutes (request, reply, configuration, enableCSP) {
-  if (enableCSP === true) {
+  if (enableCSP === true && configuration.contentSecurityPolicy !== false) {
     const cspDirectives = configuration.contentSecurityPolicy
       ? configuration.contentSecurityPolicy.directives
       : helmet.contentSecurityPolicy.getDefaultDirectives()

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -286,6 +286,44 @@ test('It should not set default directives when route useDefaults is set to `fal
   t.assert.deepStrictEqual(actualResponseHeaders, expected)
 })
 
+test('It should not set `content-security-policy` header, if route contentSecurityPolicy is false', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  await fastify.register(helmet, {
+    global: false,
+    enableCSPNonces: false,
+    contentSecurityPolicy: {
+      directives: {}
+    }
+  })
+
+  fastify.get(
+    '/',
+    {
+      helmet: {
+        contentSecurityPolicy: false
+      }
+    },
+    (request, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  )
+
+  const response = await fastify.inject({ method: 'GET', path: '/' })
+
+  const expected = {
+    'content-security-policy': undefined
+  }
+
+  const actualResponseHeaders = {
+    'content-security-policy': response.headers['content-security-policy']
+  }
+
+  t.assert.deepStrictEqual(actualResponseHeaders, expected)
+})
+
 test('It should be able to conditionally apply the middlewares through the `helmet` reply decorator', async (t) => {
   t.plan(10)
 


### PR DESCRIPTION
Hello and thanks for great project!

I noticed, that currently the `contentSecurityPolicy: false` **is allowed by types** (since it is a original's `helmet` valid configuration), but is **not actually respected** by `@fastify/helmet` and always falls back to `helmet` defaults.
So now it is not possible to remove `Content-Security-Policy` header for one specific route, even though configuration typings are allowing for that and the rest of the headers supports that - which is pretty confusing 😢 

It happens because of how CSP Nonce generation feature is currently implemented and i have added a fix for that + test, so `contentSecurityPolicy: false` is also respected at individual route level.

Documentation is not changed, since don't think it is needed - current docs are describing the way to pass custom `helmet` configration for specific routes and `contentSecurityPolicy: false` is a valid case of `helmet` configuration.
I had checked that in the checklist anyway, since there is no other option to highlight that documentation doesn't need any further changes in this PR


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
