### PR TITLE
docs: use cross-platform compatible info emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ fastify.get('/route-with-custom-helmet-configuration', {
 `@fastify/helmet` also allows CSP nonce generation, which can be enabled by passing `{ enableCSPNonces: true }` into the options.
 Retrieve the `nonces` through `reply.cspNonce`.
 
-> 🛈 Note: This feature is implemented by this module and is not supported by `helmet`.
+> ℹ️ Note: This feature is implemented by this module and is not supported by `helmet`.
 > For using `helmet` only for csp nonces, see [example](#example---generate-by-helmet).
 
 #### Example - Generate by options


### PR DESCRIPTION
Previous icon was not visible in Safari. See https://github.com/fastify/fastify/pull/6132#discussion_r2097602170