### PR TITLE
Support function-based customisation in reply.helmet options

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ fastify.get('/here-we-use-helmet-reply-decorator', async (request, reply) => {
   } else {
     // we apply customized options
     await reply.helmet({ frameguard: false })
+    // you can also pass a function returning customized options
+    // await reply.helmet((opts) => {
+    //   opts.frameguard = false
+    //   return opts
+    // })
   }
 
   return {

--- a/index.js
+++ b/index.js
@@ -88,9 +88,13 @@ async function replyDecorators (request, reply, configuration, enableCSP) {
   }
 
   reply.helmet = function (opts) {
-    const helmetConfiguration = opts
-      ? Object.assign(Object.create(null), configuration, opts)
-      : configuration
+    let helmetConfiguration = configuration
+
+    if (typeof opts === 'function') {
+      helmetConfiguration = opts(structuredClone(helmetConfiguration))
+    } else if (opts) {
+      helmetConfiguration = Object.assign(Object.create(null), configuration, opts)
+    }
 
     return helmet(helmetConfiguration)(request.raw, reply.raw, done)
   }
@@ -135,6 +139,7 @@ async function buildHelmetOnRoutes (request, reply, configuration, enableCSP) {
 
 // Helmet forward a typeof Error object so we just need to throw it as is.
 function done (error) {
+  /* c8 ignore next */
   if (error) throw error
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,7 @@ declare module 'fastify' {
       script: string;
       style: string;
     },
-    helmet: (opts?: HelmetOptions) => typeof helmet
+    helmet: (opts?: HelmetOptions | ((opts: HelmetOptions) => HelmetOptions)) => typeof helmet
   }
 
   export interface RouteOptions extends fastifyHelmet.FastifyHelmetRouteOptions { }


### PR DESCRIPTION
Added support for passing a function to `reply.helmet`, allowing dynamic modification of Helmet options. Updated type definitions and included tests to validate this functionality. The aim is to make updating the existing options easier, without needing to overwrite the entire object (i.e. when modifying a specific CSP value).

```js
await reply.helmet(opts => {
  opts.contentSecurityPolicy.directives['script-src'].push('nonce-123')
  return opts
})
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
