### PR TITLE
refactor: remove usage of deprecated request.routeConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,7 @@ async function fastifyHelmet (fastify, options) {
   })
 
   fastify.addHook('onRequest', async function helmetConfigureReply (request, reply) {
-    /* c8 ignore next */
-    const { helmet: routeOptions } = request.routeOptions?.config || request.routeConfig
+    const { helmet: routeOptions } = request.routeOptions?.config
 
     if (routeOptions !== undefined) {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -51,8 +50,7 @@ async function fastifyHelmet (fastify, options) {
   })
 
   fastify.addHook('onRequest', function helmetApplyHeaders (request, reply, next) {
-    /* c8 ignore next */
-    const { helmet: routeOptions } = request.routeOptions?.config || request.routeConfig
+    const { helmet: routeOptions } = request.routeOptions?.config
 
     if (routeOptions !== undefined) {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -135,6 +133,7 @@ async function buildHelmetOnRoutes (request, reply, configuration, enableCSP) {
 
 // Helmet forward a typeof Error object so we just need to throw it as is.
 function done (error) {
+  /* c8 ignore next */
   if (error) throw error
 }
 

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -848,8 +848,7 @@ test('It should not return a fastify `FST_ERR_REP_ALREADY_SENT - Reply already s
           }
 
           // We want to crash in the scope of this test
-          const crash =
-            request.routeOptions?.config?.fail || request.routeConfig.fail
+          const crash = request.routeOptions?.config?.fail
 
           Promise.resolve(crash)
             .then((fail) => {


### PR DESCRIPTION
`request.routeConfig` was removed in Fastify v5
ref. https://fastify.dev/docs/latest/Guides/Migration-Guide-V5/#streamlined-access-to-route-definition

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
