### PR TITLE
perf(index): remove redundant optional chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function fastifyHelmet (fastify, options) {
   })
 
   fastify.addHook('onRequest', async function helmetConfigureReply (request, reply) {
-    const { helmet: routeOptions } = request.routeOptions?.config
+    const { helmet: routeOptions } = request.routeOptions.config
 
     if (routeOptions !== undefined) {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions
@@ -50,7 +50,7 @@ async function fastifyHelmet (fastify, options) {
   })
 
   fastify.addHook('onRequest', function helmetApplyHeaders (request, reply, next) {
-    const { helmet: routeOptions } = request.routeOptions?.config
+    const { helmet: routeOptions } = request.routeOptions.config
 
     if (routeOptions !== undefined) {
       const { enableCSPNonces: enableRouteCSPNonces, skipRoute, ...helmetRouteConfiguration } = routeOptions


### PR DESCRIPTION
`routeOptions.config` is always defined, so the optional chaining is redundant. Redundant optional chaining has a small performance impact: https://adventures.nodeland.dev/archive/noop-functions-vs-optional-chaining-a-performance/

For example, a basic route of:
```js
fastify.get('/', async () => {
    return { message: 'ok' }
  })
```
would have the following `routeOptions` property:

```js
{
  method: "GET",
  url: "/",
  bodyLimit: 1048576,
  attachValidation: false,
  logLevel: "",
  exposeHeadRoute: true,
  prefixTrailingSlash: "both",
  handler: function () { [native code] },
  config: {
    url: "/",
    method: "GET",
  },
  schema: undefined,
  version: undefined,
}
```



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
