### PR TITLE
chore(package.json): fix delvedor's personal url

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "contributors": [
     {
       "name": "Tomas Della Vedova",
-      "url": "http://delved.org"
+      "url": "https://delvedor.dev"
     },
     {
       "name": "Manuel Spigolon",


### PR DESCRIPTION
Old link no longer exists