### PR TITLE
test: fix CSP header order assertions for helmet@8.3.x

### DIFF
--- a/test/global.test.js
+++ b/test/global.test.js
@@ -277,7 +277,7 @@ test('It should allow merging options for enableCSPNonces', async (t) => {
   t.assert.ok(cspCache.style)
   t.assert.deepStrictEqual(
     response.headers['content-security-policy'],
-    `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+    `default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self' 'nonce-${cspCache.script}';script-src-attr 'none';style-src 'self' 'nonce-${cspCache.style}';upgrade-insecure-requests`
   )
 })
 
@@ -340,7 +340,7 @@ test('It should not stack nonce array in csp header', async (t) => {
   t.assert.ok(cspCache.style)
   t.assert.deepStrictEqual(
     response.headers['content-security-policy'],
-    `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+    `default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self' 'nonce-${cspCache.script}';script-src-attr 'none';style-src 'self' 'nonce-${cspCache.style}';upgrade-insecure-requests`
   )
 
   response = await fastify.inject({ method: 'GET', path: '/' })
@@ -350,7 +350,7 @@ test('It should not stack nonce array in csp header', async (t) => {
   t.assert.ok(cspCache.style)
   t.assert.deepStrictEqual(
     response.headers['content-security-policy'],
-    `default-src 'self';script-src 'self' 'nonce-${cspCache.script}';style-src 'self' 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+    `default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self' 'nonce-${cspCache.script}';script-src-attr 'none';style-src 'self' 'nonce-${cspCache.style}';upgrade-insecure-requests`
   )
 })
 
@@ -380,7 +380,7 @@ test('It should access the correct options property', async (t) => {
   t.assert.ok(cspCache.style)
   t.assert.deepStrictEqual(
     response.headers['content-security-policy'],
-    `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'nonce-${cspCache.script}';style-src 'self' 'unsafe-inline' 'nonce-${cspCache.style}';default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+    `default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self' 'unsafe-eval' 'unsafe-inline' 'nonce-${cspCache.script}';script-src-attr 'none';style-src 'self' 'unsafe-inline' 'nonce-${cspCache.style}';upgrade-insecure-requests`
   )
 })
 
@@ -409,7 +409,7 @@ test('It should not set script-src or style-src', async (t) => {
   t.assert.ok(cspCache.style)
   t.assert.deepStrictEqual(
     response.headers['content-security-policy'],
-    `default-src 'self';script-src 'nonce-${cspCache.script}';style-src 'nonce-${cspCache.style}';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+    `default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'nonce-${cspCache.script}';script-src-attr 'none';style-src 'nonce-${cspCache.style}';upgrade-insecure-requests`
   )
 })
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -139,7 +139,7 @@ test('It should add CSPNonce decorator and hooks when route `enableCSPNonces` op
   const cspCache = response.json()
 
   const expected = {
-    'content-security-policy': `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'nonce-${cspCache.script}';style-src 'self' 'unsafe-inline' 'nonce-${cspCache.style}';default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+    'content-security-policy': `default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self' 'unsafe-eval' 'unsafe-inline' 'nonce-${cspCache.script}';script-src-attr 'none';style-src 'self' 'unsafe-inline' 'nonce-${cspCache.style}';upgrade-insecure-requests`
   }
 
   const actualResponseHeaders = {


### PR DESCRIPTION
Proposal:

- Fixes 5 failing CI tests in `test/global.test.js` and `test/routes.test.js` ( see here: https://github.com/fastify/fastify-helmet/actions/runs/29719887956/job/88636982463#step:5:64 )  caused by a mismatch in the directive order of
the `content-security-policy` header. `helmet` (`^8.0.0`, resolved to `8.3.0`) changed the internal
serialization order of default CSP directives. The resulting header is semantically identical (same directives, same values, same nonce) — only the order changed, which has no meaning per the CSP spec.
- Updated the expected strings in the tests to match the new order.
